### PR TITLE
add auditlog/context.py

### DIFF
--- a/src/auditlog/context.py
+++ b/src/auditlog/context.py
@@ -1,0 +1,77 @@
+import contextlib
+import time
+from contextvars import ContextVar
+from functools import partial
+
+from django.contrib.auth import get_user_model
+from django.db.models.signals import pre_save
+
+from auditlog.models import LogEntry
+
+auditlog_value = ContextVar("auditlog_value")
+auditlog_disabled = ContextVar("auditlog_disabled", default=False)
+
+
+@contextlib.contextmanager
+def set_actor(actor, remote_addr=None):
+    """Connect a signal receiver with current user attached."""
+    # Initialize thread local storage
+    context_data = {
+        "signal_duid": ("set_actor", time.time()),
+        "remote_addr": remote_addr,
+    }
+    auditlog_value.set(context_data)
+
+    # Connect signal for automatic logging
+    set_actor = partial(_set_actor, user=actor, signal_duid=context_data["signal_duid"])
+    pre_save.connect(
+        set_actor,
+        sender=LogEntry,
+        dispatch_uid=context_data["signal_duid"],
+        weak=False,
+    )
+
+    try:
+        yield
+    finally:
+        try:
+            auditlog = auditlog_value.get()
+        except LookupError:
+            pass
+        else:
+            pre_save.disconnect(sender=LogEntry, dispatch_uid=auditlog["signal_duid"])
+
+
+def _set_actor(user, sender, instance, signal_duid, **kwargs):
+    """Signal receiver with extra 'user' and 'signal_duid' kwargs.
+
+    This function becomes a valid signal receiver when it is curried with the actor and a dispatch id.
+    """
+    try:
+        auditlog = auditlog_value.get()
+    except LookupError:
+        pass
+    else:
+        if signal_duid != auditlog["signal_duid"]:
+            return
+        auth_user_model = get_user_model()
+        if (
+            sender == LogEntry
+            and isinstance(user, auth_user_model)
+            and instance.actor is None
+        ):
+            instance.actor = user
+
+        instance.remote_addr = auditlog["remote_addr"]
+
+
+@contextlib.contextmanager
+def disable_auditlog():
+    token = auditlog_disabled.set(True)
+    try:
+        yield
+    finally:
+        try:
+            auditlog_disabled.reset(token)
+        except LookupError:
+            pass


### PR DESCRIPTION
# Description

This will allow us to mock the user for different audit log operations.
Documentation: https://django-auditlog.readthedocs.io/en/latest/usage.html#set-actor
Directly copied this file: https://github.com/jazzband/django-auditlog/blob/master/auditlog/context.py

Example use cases:
1. mock that the nutiliti vendor is the one sending webhook requests
2. mock the person doing a flatfile upload (rather than it being async

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have requested review from 2 engineers, at least one of which is on a different team
