### PR TITLE
Add custom signals

### DIFF
--- a/src/auditlog/receivers.py
+++ b/src/auditlog/receivers.py
@@ -4,6 +4,7 @@ import json
 
 from auditlog.diff import model_instance_diff
 from auditlog.models import LogEntry
+from auditlog.signals import pre_log, post_log
 
 
 def log_create(sender, instance, created, **kwargs):
@@ -15,10 +16,11 @@ def log_create(sender, instance, created, **kwargs):
     if created:
         changes = model_instance_diff(None, instance)
 
-        log_entry = LogEntry.objects.log_create(
-            instance,
-            action=LogEntry.Action.CREATE,
-            changes=json.dumps(changes),
+        _create_log_entry(
+            action=LogEntry.Action.CREATE, 
+            instance=instance, 
+            sender=sender, 
+            changes=changes
         )
 
 
@@ -40,10 +42,11 @@ def log_update(sender, instance, **kwargs):
 
             # Log an entry only if there are changes
             if changes:
-                log_entry = LogEntry.objects.log_create(
-                    instance,
-                    action=LogEntry.Action.UPDATE,
-                    changes=json.dumps(changes),
+                _create_log_entry(
+                    action=LogEntry.Action.UPDATE, 
+                    instance=instance, 
+                    sender=sender, 
+                    changes=changes
                 )
 
 
@@ -56,8 +59,48 @@ def log_delete(sender, instance, **kwargs):
     if instance.pk is not None:
         changes = model_instance_diff(instance, None)
 
+        _create_log_entry(
+            action=LogEntry.Action.DELETE, 
+            instance=instance, 
+            sender=sender, 
+            changes=changes
+        )
+
+    
+def _create_log_entry(action, instance, sender, changes):
+    pre_log_results = pre_log.send(
+        sender,
+        instance=instance,
+        action=action,
+    )
+
+    if any(item[1] is False for item in pre_log_results):
+        return
+
+    json_changes = json.dumps(changes)
+    log_entry = None
+    error = None
+
+    try:
         log_entry = LogEntry.objects.log_create(
             instance,
-            action=LogEntry.Action.DELETE,
-            changes=json.dumps(changes),
+            action=action,
+            changes=json_changes,
         )
+    except BaseException as e:
+        error = e
+    finally:
+        if log_entry or error:
+            post_log.send(
+                sender,
+                instance=instance,
+                action=action,
+                changes=json_changes,
+                log_entry=log_entry,
+                log_created=log_entry is not None,
+                error=error,
+                pre_log_results=pre_log_results,
+            )
+
+        if error:
+            raise error

--- a/src/auditlog/signals.py
+++ b/src/auditlog/signals.py
@@ -1,0 +1,70 @@
+import django.dispatch
+
+accessed = django.dispatch.Signal()
+
+
+pre_log = django.dispatch.Signal()
+"""
+Whenever an audit log entry is written, this signal
+is sent before writing the log.
+Keyword arguments sent with this signal:
+
+:param class sender:
+    The model class that's being audited.
+
+:param Any instance:
+    The actual instance that's being audited.
+
+:param Action action:
+    The action on the model resulting in an
+    audit log entry. Type: :class:`auditlog.models.LogEntry.Action`
+
+The receivers' return values are sent to any :func:`post_log`
+signal receivers, with one exception: if any receiver returns False,
+no logging will be made. This can be useful if logging should be
+conditionally enabled / disabled
+"""
+
+post_log = django.dispatch.Signal()
+"""
+Whenever an audit log entry is written, this signal
+is sent after writing the log.
+This signal is also fired when there is an error in creating the log.
+
+Keyword arguments sent with this signal:
+
+:param class sender:
+    The model class that's being audited.
+
+:param Any instance:
+    The actual instance that's being audited.
+
+:param Action action:
+    The action on the model resulting in an
+    audit log entry. Type: :class:`auditlog.models.LogEntry.Action`
+
+:param Optional[dict] changes:
+    The changes that were logged. If there was en error while determining the changes,
+    this will be None. In some cases, such as when logging access to the instance,
+    the changes will be an empty dict.
+
+:param Optional[LogEntry] log_entry:
+    The log entry that was created and stored in the database. If there was an error,
+    this will be None.
+
+:param bool log_created:
+    Was the log actually created?
+    This could be false if there was an error in creating the log.
+
+:param Optional[Exception] error:
+    The error, if one occurred while saving the audit log entry. ``None``,
+    otherwise
+
+:param List[Tuple[method,Any]] pre_log_results:
+    List of tuple pairs ``[(pre_log_receiver, pre_log_response)]``, where
+    ``pre_log_receiver`` is the receiver method, and ``pre_log_response`` is the
+    corresponding response of that method. If there are no :const:`pre_log` receivers,
+    then the list will be empty. ``pre_log_receiver`` is guaranteed to be
+    non-null, but ``pre_log_response`` may be ``None``. This depends on the corresponding
+    ``pre_log_receiver``'s return value.
+"""

--- a/src/auditlog_tests/tests.py
+++ b/src/auditlog_tests/tests.py
@@ -870,7 +870,7 @@ class SignalTests(TestCase):
         class CustomSignalError(BaseException):
             pass
 
-        def post_log_receiver(error, **_kwargs):
+        def post_log_receiver(sender, instance, action, error, **_kwargs):
             self.my_post_log_data["my_error"] = error
 
         post_log.connect(post_log_receiver)


### PR DESCRIPTION
## **User description**
# Description
Adding Custom signals from django-auditlog v3 https://django-auditlog.readthedocs.io/en/latest/internals.html#auditlog.signals.pre_log to our forked version. 

Primarily copied code from [receivers](https://github.com/jazzband/django-auditlog/blob/master/auditlog/receivers.py), [signals](https://github.com/jazzband/django-auditlog/blob/master/auditlog/signals.py) and [tests](https://github.com/jazzband/django-auditlog/blob/master/auditlog_tests/tests.py)

This decision is per the tech design to track ONLY transaction updates in the auditlog for ElasticSearch syncing.

## Type of change
- [ ] Chore (non-breaking change which has no end user impact)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

 
# Testing Plan
 
# Checklist:
- [x] I have performed a self-review of my code
- [x] I have requested review from 2 engineers, at least one of which is on a different team
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules


___

## **CodeAnt-AI Description**
**Add pre_log and post_log hooks around audit entries**

### What Changed
- Create/update/delete logging now sends a pre_log signal that can stop a log entry, and post_log runs afterward with success/failure details.
- post_log always fires even when saving the entry raises an error so listeners can observe audit failures.
- Added signal-focused tests covering invocation, disabling logging, and error propagation.

### Impact
`✅ Fewer audit entries when custom signals disable logging`
`✅ Clearer audit failures via post_log notifications`
`✅ Signal-based hooks for selective ElasticSearch syncing`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
